### PR TITLE
#8 CrmDbContext Oluşturuldu.

### DIFF
--- a/Infrastructure/CRM.Persistance/Context/CrmDbContext.cs
+++ b/Infrastructure/CRM.Persistance/Context/CrmDbContext.cs
@@ -1,0 +1,25 @@
+﻿using CRM.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using System.Reflection;
+
+namespace CRM.Persistence.Context
+{
+	public class CrmDbContext : DbContext
+	{
+		public CrmDbContext(DbContextOptions options) : base(options)
+		{
+		}
+
+		public DbSet<Customer> Customers { get; set; }
+		public DbSet<Address> Addresses { get; set; }
+
+		protected override void OnModelCreating(ModelBuilder modelBuilder)
+		{
+			// Bulunduğumuz Assembly'deki (Persistence projesi) 
+			// tüm IEntityTypeConfiguration implementasyonlarını bul ve uygula.
+			modelBuilder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
+
+			base.OnModelCreating(modelBuilder);
+		}
+	}
+}


### PR DESCRIPTION
Add CrmDbContext for Entity Framework integration

Introduces the `CrmDbContext` class inheriting from `DbContext` to serve as the database context for the CRM application. This class includes `DbSet` properties for `Customer` and `Address` entities and overrides the `OnModelCreating` method to apply configurations from the current assembly, enhancing modularity in entity configuration.